### PR TITLE
add missing links to NextCloud and data secrecy page

### DIFF
--- a/project-manual/project-coordinators/scoping.md
+++ b/project-manual/project-coordinators/scoping.md
@@ -129,7 +129,7 @@ Most of the times, CorrelAid teams will get a pseudonymized version of the data 
 
 * DO: encrypt the data on local machines (see [howto](../data-security-and-privacy.md#data-encryption))
 * DO NOT: upload data to GitHub / GitLab (see howto)
-* DO: team members and NPO need to sign the _obligation to observe data secrecy_ _\*\*_(de: Datenschutzverpflichtungserklärung) (download it here)
+* DO: team members and NPO need to sign the _obligation to observe data secrecy_ _\*\*_(de: Datenschutzverpflichtungserklärung) (see [here](../data-security-and-privacy.md#declaration-on-data-security))
 * DO (if very sensitive data): team members create separate user account on their machine just for the project
 {% endhint %}
 

--- a/wiki/infrastructure/google-workspace.md
+++ b/wiki/infrastructure/google-workspace.md
@@ -39,7 +39,7 @@ group email:&#x20;
 
 ###
 
-### Accessing personal mails
+### Accessing personal emails
 
 You can access your personal emails via one of the following ways:
 
@@ -134,7 +134,7 @@ Tip: Download [Drive for Desktop](https://www.google.com/drive/download/) (MacOS
 
 * store project data from NPO partners if it is [GDPR relevant](../../project-manual/data-security-and-privacy.md#personal-data-gdpr)
 * store any other project data from NPO partners
-* don't store/write down [special characteristics](https://gdpr-info.eu/art-9-gdpr/) (ethnicity, religion, political beliefs...) of other people (also incl. Google Docs/Google Sheets) -> for those cases, please use NextCloud or a [private CodiMD](codimd.md#setting-permissions).
+* don't store/write down [special characteristics](https://gdpr-info.eu/art-9-gdpr/) (ethnicity, religion, political beliefs...) of other people (also incl. Google Docs/Google Sheets) -> for those cases, please use [NextCloud](correlcloud.md) or a [private CodiMD](codimd.md#setting-permissions).
 
 :warning:**Under certain circumstances**
 


### PR DESCRIPTION
I found these two missing links while reading the docs.

I also saw the `_\*\*_` before the German translation of the data secrecy document. 
I was going to delete it but didn't know if it meant something that I wasn't aware.